### PR TITLE
Fix Xcode warnings for constants, downcasting and dead code

### DIFF
--- a/RadarCovid/Application/JailBreakDetect.swift
+++ b/RadarCovid/Application/JailBreakDetect.swift
@@ -15,7 +15,7 @@ import UIKit
 class JailBreakDetect {
 
     static var isSimulator: Bool {
-        #if arch(i386) || arch(x86_64)
+        #if targetEnvironment(simulator)
             return true
         #else
             return false

--- a/RadarCovid/Application/JailBreakDetect.swift
+++ b/RadarCovid/Application/JailBreakDetect.swift
@@ -14,6 +14,14 @@ import UIKit
 
 class JailBreakDetect {
 
+    static var isSimulator: Bool {
+        #if arch(i386) || arch(x86_64)
+            return true
+        #else
+            return false
+        #endif
+    }
+
     static func isJailbroken() -> Bool {
 
         guard let cydiaUrlScheme = NSURL(string: "cydia://package/com.example.package") else { return false }
@@ -21,11 +29,7 @@ class JailBreakDetect {
             return true
         }
 
-        #if arch(i386) || arch(x86_64)
-            // This is a Simulator not an idevice
-            return false
-
-        #else
+        guard !isSimulator else { return false }
 
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: "/Applications/Cydia.app") ||
@@ -55,7 +59,7 @@ class JailBreakDetect {
         } catch {
             return false
         }
-        #endif
+
     }
 
     static func canOpen(path: String) -> Bool {

--- a/RadarCovid/Application/JailBreakDetect.swift
+++ b/RadarCovid/Application/JailBreakDetect.swift
@@ -24,7 +24,8 @@ class JailBreakDetect {
         #if arch(i386) || arch(x86_64)
             // This is a Simulator not an idevice
             return false
-        #endif
+
+        #else
 
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: "/Applications/Cydia.app") ||
@@ -54,6 +55,7 @@ class JailBreakDetect {
         } catch {
             return false
         }
+        #endif
     }
 
     static func canOpen(path: String) -> Bool {

--- a/RadarCovid/Data/WS/Config/Models/TextCustomMap.swift
+++ b/RadarCovid/Data/WS/Config/Models/TextCustomMap.swift
@@ -42,7 +42,7 @@ public struct TextCustomMap: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: String.self)
 
-        var nonAdditionalPropertyKeys = Set<String>()
+        let nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(String.self, excludedKeys: nonAdditionalPropertyKeys)
     }
 

--- a/RadarCovid/Data/WS/Models.swift
+++ b/RadarCovid/Data/WS/Models.swift
@@ -31,9 +31,9 @@ open class Response<T> {
     }
 
     public convenience init(response: HTTPURLResponse, body: T?) {
-        let rawHeader = response.allHeaderFields as! [String: String]
+        let rawHeader = response.allHeaderFields
         var header = [String: String]()
-        for case let (key, value) in rawHeader {
+        for case let (key as String, value as String) in rawHeader {
             header[key] = value
         }
         self.init(statusCode: response.statusCode, header: header, body: body)

--- a/RadarCovid/Data/WS/Models.swift
+++ b/RadarCovid/Data/WS/Models.swift
@@ -31,9 +31,9 @@ open class Response<T> {
     }
 
     public convenience init(response: HTTPURLResponse, body: T?) {
-        let rawHeader = response.allHeaderFields
+        let rawHeader = response.allHeaderFields as! [String: String]
         var header = [String: String]()
-        for case let (key, value) as (String, String) in rawHeader {
+        for case let (key, value) in rawHeader {
             header[key] = value
         }
         self.init(statusCode: response.statusCode, header: header, body: body)

--- a/RadarCovid/Data/WS/Models.swift
+++ b/RadarCovid/Data/WS/Models.swift
@@ -33,8 +33,10 @@ open class Response<T> {
     public convenience init(response: HTTPURLResponse, body: T?) {
         let rawHeader = response.allHeaderFields
         var header = [String: String]()
-        for case let (key as String, value as String) in rawHeader {
-            header[key] = value
+        for (key, value) in rawHeader {
+              if let key = key as? String, let value = value as? String {
+                    header[key] = value
+              }
         }
         self.init(statusCode: response.statusCode, header: header, body: body)
     }


### PR DESCRIPTION
* Use `let` instead var for constants when possible.
* Fixed downcasting to unrelated types warnings.
* Fixed dead code warnings using `#if` `#else` `#endif` when possible.