### PR TITLE
Fixing minor typos in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Before you submit a new pull-request, please check the following few things:
 
 ## Why did my issue/PR get closed?
 
-We are currently focused on national rollout. Hence, we try to keep the changes to a minimum and expect to take care of PRs in medium term. Please, be patience.
+We are currently focused on national rollout. Hence, we try to keep the changes to a minimum and expect to take care of PRs in medium term. Please, be patient.
 
 Proposed changes exclusively related to the tools we use should be thoroughly justified. We use a set of tools and configurations that we are used to. Therefore, unless strong arguments for changes are provided, we probably won't change it.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The project can be built with the indicated Xcode version. Dependencies are mana
 
 The project is configured for a specific provisioning profile. To install the app on your own device, you will have to update the settings using your own provisioning profile.
 
-Apples Exposure Notification Framework requires a  `com.apple.developer.exposure-notification` entitlement that will only be available to government entities. You will find more information in the [Exposure Notification Addendum](https://developer.apple.com/contact/request/download/Exposure_Notification_Addendum.pdf) and you can request the entitlement  [here](https://developer.apple.com/contact/request/exposure-notification-entitlement).
+Apple's Exposure Notification Framework requires a  `com.apple.developer.exposure-notification` entitlement that will only be available to government entities. You will find more information in the [Exposure Notification Addendum](https://developer.apple.com/contact/request/download/Exposure_Notification_Addendum.pdf) and you can request the entitlement  [here](https://developer.apple.com/contact/request/exposure-notification-entitlement).
 
 ### Commit Lint
 It's possible to install a git hook to authomatically check commit comments based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.


### PR DESCRIPTION
🔑 There are a couple of typos in the aforementioned files.
In **README.md**
> Apples Exposure Notification Framework requires a...

Saxon genitive should be use to express Apple's possession of the framework.

In **CONTRIBUTING.MD**
> ... Please, be patience.

This sentence should use the adjective (`patient`) instead of the noun (`patience`).